### PR TITLE
fix: add tinacms build step to production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "tinacms dev -c \"next dev --turbopack\"",
-    "build": "next build",
+    "build": "tinacms build && next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
## Summary
- Adds `tinacms build` before `next build` in the build script
- Without this, the admin panel assets are not generated for production, causing a 404 on `/admin`

## Test plan
- [ ] Verify Vercel build succeeds
- [ ] Verify `https://rememberamirzur.co.il/admin/index.html` loads the TinaCMS admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)